### PR TITLE
fix a missing :: to access rmarkdown's function

### DIFF
--- a/R/chapter.R
+++ b/R/chapter.R
@@ -34,7 +34,7 @@ tex_chapter <- function(chapter = NULL,
       to = "latex",
       from = "markdown_style",
       ext = ".tex",
-      args = c("--chapters", pandoc_latex_engine_args(latex_engine))
+      args = c("--chapters", rmarkdown::pandoc_latex_engine_args(latex_engine))
     ),
     clean_supporting = FALSE
   )


### PR DESCRIPTION
This partially fixes the problem reported at ggplot2-book (https://github.com/hadley/ggplot2-book/issues/104)