### PR TITLE
markdown_style is not a string, a variable

### DIFF
--- a/R/chapter.R
+++ b/R/chapter.R
@@ -32,7 +32,7 @@ tex_chapter <- function(chapter = NULL,
     knitr_opts("html", chapter),
     rmarkdown::pandoc_options(
       to = "latex",
-      from = "markdown_style",
+      from = markdown_style,
       ext = ".tex",
       args = c("--chapters", pandoc_latex_engine_args(latex_engine))
     ),


### PR DESCRIPTION
`markdown_style` seems mistakenly wrapped with double-quotes.

This PR fixes https://github.com/hadley/ggplot2-book/issues/104.